### PR TITLE
Updated FALDO comments

### DIFF
--- a/faldo.ttl
+++ b/faldo.ttl
@@ -14,7 +14,7 @@
 
 :BothStrandsPosition
       rdf:type owl:Class ;
-      rdfs:comment "The both strands position mean that the region spans both strands instead of one. In GGF3 displayed as 0. This does not mean that the position is one or the other strand but is best described as being on both."^^xsd:string ;
+      rdfs:comment "The 'both strands position' means that the region spans both strands instead of one. In GFF3 displayed as 0. This does not mean that the position is one or the other strand, but that is best described as being on both."^^xsd:string ;
       rdfs:label "Both strands"^^xsd:string ;
       rdfs:subClassOf :StrandedPosition ;
       owl:disjointWith :ForwardStrandPosition , :ReverseStrandPosition .
@@ -33,7 +33,7 @@
 
 :ForwardStrandPosition
       rdf:type owl:Class ;
-      rdfs:comment "The position is on the forward (positive) strand. Shown as a '+' in GFF3 and GTF"^^xsd:string ;
+      rdfs:comment "The position is on the forward (positive, 5' to 3') strand. Shown as a '+' in GFF3 and GTF."^^xsd:string ;
       rdfs:label "Positive strand"^^xsd:string ;
       rdfs:subClassOf :StrandedPosition ;
       owl:disjointWith :BothStrandsPosition , :ReverseStrandPosition .
@@ -46,7 +46,7 @@
 
 :InBetweenPosition
       rdf:type owl:Class ;
-      rdfs:comment "This denotes that a feature is in between two other positions that are both known exactly and next to eaxh other. An example is an restriction enzyme cutting site. The cut is after one nucleotide and before the next i.e. in between"^^xsd:string ;
+      rdfs:comment "This denotes that a feature is in between two other positions that are both known exactly and next to each other. An example is a restriction enzyme cutting site. The cut is after one nucleotide position and before another nucleotide position (hence, in between)."^^xsd:string ;
       rdfs:label "In between positions"^^xsd:string ;
       rdfs:subClassOf :Position ;
       rdfs:subClassOf
@@ -67,7 +67,7 @@
 
 :InRangePosition
       rdf:type owl:Class ;
-      rdfs:comment "Use when you have an idea of the range in which you can find the position but can not be sure."^^xsd:string ;
+      rdfs:comment "Use when you have an idea of the range in which you can find the position, but you cannot be sure about the exact position."^^xsd:string ;
       rdfs:label "Indeterminate position within a range"^^xsd:string ;
       rdfs:subClassOf :FuzzyPosition ;
       rdfs:subClassOf
@@ -88,7 +88,7 @@
 
 :OneOfPosition
       rdf:type owl:Class ;
-      rdfs:comment "The position must be one of the more detailed Positions listed by the location predicate."^^xsd:string ;
+      rdfs:comment "The position must be one of the more detailed positions listed by the location predicate."^^xsd:string ;
       rdfs:label "One of positions"^^xsd:string ;
       rdfs:subClassOf :FuzzyPosition ;
       owl:disjointWith :InBetweenPosition , :InRangePosition , :ExactPosition .
@@ -106,7 +106,7 @@
 
 :Region
       rdf:type owl:Class ;
-      rdfs:comment "A region describes an length of sequence with a start and end position that represents a feature on a Sequence. i.e. a gene"^^xsd:string ;
+      rdfs:comment "A region describes a length of sequence -- with a start position and end position -- that represents a feature on a Sequence. i.e. a gene"^^xsd:string ;
       rdfs:label "Region"^^xsd:string ;
       rdfs:subClassOf owl:Thing ;
       rdfs:subClassOf
@@ -126,32 +126,32 @@
 
 :ReverseStrandPosition
       rdf:type owl:Class ;
-      rdfs:comment "The position is on the reverse (complement) strand of the sequence. Shown as '-' in GTF and GFF3"^^xsd:string ;
+      rdfs:comment "The position is on the reverse (complement, 3' to 5') strand of the sequence. Shown as '-' in GTF and GFF3."^^xsd:string ;
       rdfs:label "Negative strand"^^xsd:string ;
       rdfs:subClassOf :StrandedPosition ;
       owl:disjointWith :ForwardStrandPosition , :BothStrandsPosition .
 
 :StrandedPosition
       rdf:type owl:Class ;
-      rdfs:comment "Part of the coordinate system is on which strand the feature can be found. If you do not yet know which stand the feature is on you should tag the position with just this class. If you know more you should use one of the subclasses. This means a region descibred with a '.' in GFF3. An GFF3 Unstranded position does not have this type in FALDO those are just a Position."^^xsd:string ;
+      rdfs:comment "Part of the coordinate system denoting on which strand the feature can be found. If you do not yet know which stand the feature is on, you should tag the position with just this class. If you know more you should use one of the subclasses. This means a region descibred with a '.' in GFF3. A GFF3 unstranded position does not have this type in FALDO -- those are just a 'position'."^^xsd:string ;
       rdfs:label "Stranded position"^^xsd:string ;
       rdfs:subClassOf :Position .
 
 :after
       rdf:type owl:ObjectProperty ;
-      rdfs:comment "This predicate is used when you want to describe a non inclusive range. Only used in the in between position to say it is after a nucleotide but before the next one."^^xsd:string ;
+      rdfs:comment "This predicate is used when you want to describe a non-inclusive range. Only used in the in between position to say it is after a nucleotide, but before the next one."^^xsd:string ;
       rdfs:domain :InBetweenPosition ;
       rdfs:range :ExactPosition .
 
 :before
       rdf:type owl:ObjectProperty ;
-      rdfs:comment "This used to say indicate that the feature is found before the ExactPosition. Use to indicate for example a cleavage site. The cleavage happens between two amino acids before one and after the other."^^xsd:string ;
+      rdfs:comment "This used to indicate that the feature is found before the exact position. Use to indicate, for example, a cleavage site. The cleavage happens between two amino acids before one and after the other."^^xsd:string ;
       rdfs:domain :InBetweenPosition ;
       rdfs:range :ExactPosition .
 
 :begin
       rdf:type owl:ObjectProperty ;
-      rdfs:comment "The inclusive begin position of an position. Also known as start."^^xsd:string ;
+      rdfs:comment "The inclusive begin position of a position. Also known as start."^^xsd:string ;
       rdfs:range :Position .
 
 :end  rdf:type owl:ObjectProperty ;
@@ -160,7 +160,7 @@
 
 :location
       rdf:type owl:ObjectProperty ;
-      rdfs:comment "This is the link between the concept that you are annotating the location of and its Range or Position. e.g. when annotating the region that describes an exon, the exon would be the subject and the region would be the object of the triple or 'active site' 'location' is 'position 3'"^^xsd:string ;
+      rdfs:comment "This is the link between the concept whose location you are annotating the and its range or position. For example, when annotating the region that describes an exon, the exon would be the subject and the region would be the object of the triple or: 'active site' 'location' [is] 'position 3'."^^xsd:string ;
       rdfs:range
               [ rdf:type owl:Class ;
                 owl:unionOf (:Region :Position)
@@ -168,10 +168,10 @@
 
 :position
       rdf:type owl:DatatypeProperty ;
-      rdfs:comment "The positionValue is the offset along the reference where this position is found. Thus the only the positionValue in combination with the reference determines where a Position is."^^xsd:string , "A position on the first amino acid or nucleotide of a sequence has the value 1. i.e. Python style array indexing not java/C style."^^xsd:string ;
+      rdfs:comment "The position value is the offset along the reference where this position is found. Thus the only the position value in combination with the reference determines where a position is."^^xsd:string , "A position on the first amino acid or nucleotide of a sequence has the value 1, i.e. Python style array indexing as opposed to Java/C indexes."^^xsd:string ;
       rdfs:domain :ExactPosition ;
       rdfs:range xsd:integer .
 
 :reference
       rdf:type owl:ObjectProperty ;
-      rdfs:comment "The reference is the resource that determines where the positionValue offsets into.  For example it points to a contig or a genome assembly."^^xsd:string .
+      rdfs:comment "The reference is the resource that determines where the position value offsets into. For example, it points to a contig or a genome assembly."^^xsd:string .

--- a/uniprotfaldo.ttl
+++ b/uniprotfaldo.ttl
@@ -17,7 +17,7 @@
 
 :ProteinPosition
       rdf:type rdfs:Class ;
-      rdfs:comment "An uniprot feature is always described in relation to a UniProt sequence which is an amino acid. This can never be a StrandedPosition"^^xsd:string ;
+      rdfs:comment "An UniProt feature is always described in relation to a UniProt sequence which is an amino acid. This can never be a stranded position."^^xsd:string ;
       rdfs:subClassOf owl:Thing ;
       rdfs:subClassOf
               [ rdf:type owl:Restriction ;


### PR DESCRIPTION
I looked over the comments in FALDO and updated them for better readability and fixed some error too.

I opted to replace camel case references to classes by their spelled out English names. It appears more natural in such a small ontology.
