### PR TITLE
#27 begin, end are now owl:TransitiveProperty

### DIFF
--- a/faldo.ttl
+++ b/faldo.ttl
@@ -199,7 +199,7 @@
       rdfs:range :ExactPosition .
 
 :begin
-      rdf:type owl:ObjectProperty ;
+      rdf:type owl:ObjectProperty , owl:TransitiveProperty ;
       rdfs:comment "The inclusive beginning of a position. Also known as start."^^xsd:string ;
       rdfs:label "begin"^^xsd:string ;
       rdfs:domain
@@ -215,7 +215,7 @@
       rdfs:label "beginOf"^^xsd:string ;
       owl:inverseOf :begin .
 
-:end  rdf:type owl:ObjectProperty ;
+:end  rdf:type owl:ObjectProperty, owl:TransitiveProperty  ;
       rdfs:comment "The inclusive end of the position."^^xsd:string ;
       rdfs:label "end"^^xsd:string ;
       rdfs:range :Position ;


### PR DESCRIPTION
As requested in issue #27 begin and end are now transitive. So you should be able to say

```turtle
<regionsmall> faldo:begin <begin> .
<begin> a faldo:ExactPosition ; faldo:position 1 .

<regionbig> faldo:begin <regionsmall>
```
And this should infer


```turtle
<regionbig> faldo:begin <begin> .
<begin> a faldo:ExactPosition ; faldo:position 1 .
```

This should not affect the FuzzyRegions.
However, I would appreciate it if someone confirms this with a test case.